### PR TITLE
Upgrade iota.lib.js version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ build/Release
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules
 
+# User-specific stuff:
+.idea/
 
 
 \.vscode/launch\.json

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "iota.crypto.js": "iotaledger/iota.crypto.js",
-    "iota.lib.js": "^0.4.1",
+    "iota.lib.js": "^0.4.2",
     "pify": "^3.0.0",
     "rust-wasm-loader": "^0.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -738,6 +738,10 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
+bignumber.js@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
+
 binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
@@ -1646,11 +1650,12 @@ iota.crypto.js@iotaledger/iota.crypto.js:
   dependencies:
     crypto-js "^3.1.9-1"
 
-iota.lib.js@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/iota.lib.js/-/iota.lib.js-0.4.1.tgz#9c7065b882b63d2fd5d626b4a35ad39e4410f67c"
+iota.lib.js@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/iota.lib.js/-/iota.lib.js-0.4.2.tgz#f00cdaad5f692fbdb498804853e67904dc1c1aeb"
   dependencies:
     async "^2.5.0"
+    bignumber.js "^4.1.0"
     crypto-js "^3.1.9-1"
     xmlhttprequest "^1.8.0"
 


### PR DESCRIPTION
`0.4.1` throws.
![invalid api version](https://user-images.githubusercontent.com/20437468/32142966-390fcbea-bcc4-11e7-88e1-fc9a71195a9a.png)
