### PR TITLE
added function to set external iota library.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,10 @@ const subscribe = (state, channelRoot, channelKey = null) => {
   return state
 }
 
+const setIOTA = (externalIOTA) => {
+  iota = externalIOTA
+}
+
 const changeMode = (state, mode, sidekey) => {
   if (mode !== 'public' && mode !== 'private' && mode !== 'restricted')
     return console.log('Did not recognise mode!')
@@ -64,7 +68,7 @@ const changeMode = (state, mode, sidekey) => {
 }
 
 /**
- * cretae 
+ * cretae
  * @param  {object} state
  * @param  {sting} message // Tryte encoded string
  */
@@ -281,5 +285,6 @@ module.exports = {
   attach: attach,
   listen: listen,
   getRoot: getRoot,
-  setupEnv: setupEnv
+  setupEnv: setupEnv,
+  setIOTA: setIOTA
 }


### PR DESCRIPTION
Currently the only way to link a working iota library is by using `init`. This is especially difficult if you're persisting and loading the state of the mam channel, as you would have to call init again for no reason (and waste time by letting mam generate a channel you're not going to use anyway, since you have the state at hand)

By giving a method to externally set the iota library without having to init, you can avoid this and load the state directly.