### PR TITLE
return the Error object while preventing throw to be called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ const changeMode = (state, mode, sidekey) => {
 }
 
 /**
- * create 
+ * create
  * @param  {object} state
  * @param  {sting} message // Tryte encoded string
  */
@@ -238,7 +238,8 @@ const attach = async (trytes, root, depth = 6, mwm = 14) => {
     )
     return objs
   } catch (e) {
-    return console.error('failed to attach message:', '\n', e)
+    console.error('failed to attach message:', '\n', e)
+    return e
   }
 }
 


### PR DESCRIPTION
We recently tried to make our own full node for the municipality project and I got this error in my logs:

```
failed to attach message: 
 Error: Request Error: This operations cannot be executed: The subtangle has not been updated yet.
```

While obvious that the node still has to sync, it would be nice, if not required, for us to handle this error and show an appropriate message to the user (for whatever error that might be)

By returning the error object, we prevent that other projects using MAM will break (behavior stays the same), as code will still run even when the full node will return an error. The upside is that we now get returned an `error` object which one can handle should one desire to do so.